### PR TITLE
Fix loudness analysis for pyloudnorm 0.1.1

### DIFF
--- a/tests/test_loudness.py
+++ b/tests/test_loudness.py
@@ -1,0 +1,31 @@
+"""Regression tests for loudness analysis utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from track_analyser.analysis.loudness import analyse_loudness
+from track_analyser.utils import AudioInput
+
+
+def test_analyse_loudness_returns_with_pyloudnorm_installed() -> None:
+    """``analyse_loudness`` should run without raising when pyloudnorm is available."""
+
+    sample_rate = 44_100
+    duration = 0.5
+    time = np.linspace(0.0, duration, int(sample_rate * duration), endpoint=False)
+    samples = (0.1 * np.sin(2.0 * np.pi * 440.0 * time)).astype(np.float32)
+    audio = AudioInput(samples=samples, sample_rate=sample_rate)
+
+    result = analyse_loudness(audio, seed=0)
+
+    assert result.integrated_lufs is not None
+    assert result.short_term_lufs
+    assert result.momentary_lufs


### PR DESCRIPTION
## Summary
- replace deprecated pyloudnorm short-term and momentary calls with a shared sliding window LUFS helper
- fall back to percentile-based loudness range when the Meter implementation lacks loudness_range
- add a regression test that exercises analyse_loudness with pyloudnorm installed

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e03f599c0c832e8150c1ca9d15a318