### PR TITLE
Add Cython requirement to madmom optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-madmom = ["madmom==0.16.1"]
+madmom = ["madmom==0.16.1", "Cython>=0.29"]
 torch = ["torch==2.2.2"]
 demucs = ["demucs==4.0.0"]
 


### PR DESCRIPTION
## Summary
- add an explicit `Cython>=0.29` dependency to the `madmom` optional extra so the build tool is installed with the audio feature stack

## Testing
- `pip install .[madmom]` *(fails because madmom's isolated build environment does not respect externally provided Cython even though it is now declared as a dependency)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e042b013ec832e9510bbba21dc8c57