### PR TITLE
Add helper script for generating smoke-test click track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+examples/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Install deps: `pip install -r requirements.txt`
 - Install package: `pip install -e .`
 - Run tests: `pytest -q`
+- Before the CLI smoke test, generate the click track: `python scripts/make_tiny_click.py`
 - Run CLI smoke test: `track-analyser analyse examples/tiny_click_120.wav --out reports/smoke --plots --json --csv`
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -79,8 +79,17 @@ The current regression tests focus on two critical paths:
 
 When you add features, please extend or supplement these tests so we maintain coverage of the most important behaviours.
 
-For a quick manual smoke test, you can also run the CLI end-to-end:
+For a quick manual smoke test, you can also run the CLI end-to-end. First generate
+the example click track (this writes to the git-ignored `examples/` directory):
+
+```bash
+python scripts/make_tiny_click.py
+```
+
+Then analyse the generated file:
 
 ```bash
 track-analyser analyse examples/tiny_click_120.wav --out reports/smoke --plots --json --csv
 ```
+
+Because `examples/` is ignored by git, the rendered WAV stays local to your machine.

--- a/scripts/make_tiny_click.py
+++ b/scripts/make_tiny_click.py
@@ -1,0 +1,72 @@
+"""Generate a tiny click track for smoke-testing the analyser CLI."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+DEFAULT_OUTPUT = Path("examples/tiny_click_120.wav")
+SAMPLE_RATE = 44_100
+BPM = 120
+BEATS_PER_BAR = 4
+CLICK_DURATION_SECONDS = 0.03
+ACCENT_FREQUENCY = 1500.0
+REGULAR_FREQUENCY = 1000.0
+
+
+def _synth_click(frequency: float, amplitude: float, sample_rate: int, duration: float) -> np.ndarray:
+    """Return a short, exponentially decaying sine click."""
+    sample_count = int(duration * sample_rate)
+    times = np.linspace(0.0, duration, sample_count, endpoint=False)
+    envelope = np.exp(-times * 50.0)
+    waveform = amplitude * np.sin(2 * np.pi * frequency * times) * envelope
+    return waveform.astype(np.float32)
+
+
+def make_click_track(path: Path) -> Path:
+    """Create a one-bar, four-beat click track at 120 BPM."""
+    seconds_per_beat = 60.0 / BPM
+    click = _synth_click(REGULAR_FREQUENCY, 0.6, SAMPLE_RATE, CLICK_DURATION_SECONDS)
+    accent = _synth_click(ACCENT_FREQUENCY, 0.9, SAMPLE_RATE, CLICK_DURATION_SECONDS)
+
+    click_length = click.shape[0]
+    bar_samples = int(np.ceil(BEATS_PER_BAR * seconds_per_beat * SAMPLE_RATE))
+    total_samples = bar_samples + click_length
+    audio = np.zeros(total_samples, dtype=np.float32)
+
+    for beat in range(BEATS_PER_BAR):
+        start = int(round(beat * seconds_per_beat * SAMPLE_RATE))
+        end = start + click_length
+        waveform = accent if beat == 0 else click
+        audio[start:end] += waveform[: total_samples - start]
+
+    audio = np.clip(audio, -1.0, 1.0)
+
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(path, audio, SAMPLE_RATE)
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default=str(DEFAULT_OUTPUT),
+        help="Destination path for the generated WAV (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_path = Path(args.output)
+    written_path = make_click_track(output_path)
+    print(f"Wrote click track to {written_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script that synthesises a one-bar 120 BPM click track into the examples directory
- document the prerequisite script run for smoke tests and explain that examples/ is git-ignored
- ignore the examples/ directory to keep generated audio files out of version control

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e048d238c4832eb6c3b5b152083f0b