### PR TITLE
Update smoke test documentation to match CLI options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Install package: `pip install -e .`
 - Run tests: `pytest -q`
 - Before the CLI smoke test, generate the click track: `python scripts/make_tiny_click.py`
-- Run CLI smoke test: `track-analyser analyse examples/tiny_click_120.wav --out reports/smoke --plots --json --csv`
+- Run CLI smoke test: `track-analyser analyse examples/tiny_click_120.wav --output reports/smoke`
 
 ## Code style
 - Python 3.11

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python scripts/make_tiny_click.py
 Then analyse the generated file:
 
 ```bash
-track-analyser analyse examples/tiny_click_120.wav --out reports/smoke --plots --json --csv
+track-analyser analyse examples/tiny_click_120.wav --output reports/smoke
 ```
 
 Because `examples/` is ignored by git, the rendered WAV stays local to your machine. The full [smoke test runbook](RUNBOOK.md#smoke-test-end-to-end-cli-run) captures the checklist and post-run validation steps.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -38,7 +38,7 @@ Use this checklist after modifying the analysis pipeline or rendering code, or b
    ```
 3. Run the CLI against the generated file:
    ```bash
-   track-analyser analyse examples/tiny_click_120.wav --output reports/smoke --plots --json --csv
+   track-analyser analyse examples/tiny_click_120.wav --output reports/smoke
    ```
 4. Inspect the console output for the success summary, then spot-check the artefacts written to `reports/smoke` (especially the JSON and plots) to confirm the pipeline executed end-to-end.
 


### PR DESCRIPTION
## Summary
- update the README smoke test instructions to use the supported `--output` flag
- bring the RUNBOOK and contributor guidance in AGENTS.md in sync with the working smoke test command
- verified the documented options against `track-analyser analyse --help`

## Testing
- n/a (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e04b6aba98832eb6c05752250598cb