### PR TITLE
Fix CLI progress bar stage count

### DIFF
--- a/src/track_analyser/cli.py
+++ b/src/track_analyser/cli.py
@@ -67,11 +67,15 @@ def analyze_command(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        stages = 6  # audio, beats, structure, loudness, harmonic, render
         with Progress(transient=True) as progress:
-            task = progress.add_task("Analysing", total=stages)
+            task = progress.add_task("Analysing", total=0)
+
+            stages_seen = 0
 
             def _advance(_: str) -> None:
+                nonlocal stages_seen
+                stages_seen += 1
+                progress.update(task, total=stages_seen)
                 progress.advance(task)
 
             result = analyse_track(


### PR DESCRIPTION
## Summary
- update the CLI progress task to grow the total dynamically so each pipeline callback advances the bar only once
- ensure the manual render step contributes to the overall progress count so the bar completes at the end of rendering

## Testing
- pytest -q tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e12906b3a4832e8a34850e5f68fb32