### PR TITLE
Clarify README test guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ From the repository root, execute the automated suite with:
 pytest -q
 ```
 
-The current regression tests focus on two critical paths:
+The current regression tests focus on three critical paths:
 
 - `tests/test_loudness.py` checks the integrated-loudness regression to guard against changes in analysis math or default parameters.
 - `tests/test_rendering_outputs.py` verifies the report renderer to ensure the structured artefacts remain stable.


### PR DESCRIPTION
## Summary
- update the README testing section to state that three critical paths are covered by the current regression tests

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e129b4f630832ebacf9e715c8ebce3