### PR TITLE
docs: clarify Windows guidance for madmom extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install .[torch]
 pip install .[demucs]
 ```
 
-**Windows/Conda note:** install `Cython>=0.29` before running `pip install .[madmom]`. The upstream `madmom` sdist imports Cython during its build, so pre-installing it avoids failures while the extra resolves dependencies.
+**Windows/Conda note:** install `Cython>=0.29` before running the extra install, then invoke `pip install --use-pep517 .[madmom]` (or set `PIP_USE_PEP517=1`) so pip sticks to the modern build backend. The upstream `madmom` sdist imports Cython during its build and otherwise falls back to legacy `setup_requires`, which fails under Windows/Conda. See the [troubleshooting guidance](RUNBOOK.md#troubleshooting) if issues persist.
 
 When using Conda on Windows, make sure the `audio` environment is active before running `pip install` so that binaries such as `numpy` and `librosa` resolve correctly.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -33,7 +33,7 @@ Use this checklist after modifying the analysis pipeline or rendering code, or b
    pip install -r requirements.txt
    pip install -e .
    ```
-   **Windows/Conda note:** when installing optional extras like `pip install .[madmom]` for beat-tracking refinement, run `pip install Cython>=0.29` first. The upstream `madmom` sdist imports Cython during its build and fails without the pre-installed dependency.
+   **Windows/Conda note:** when installing optional extras like `pip install .[madmom]` for beat-tracking refinement, run `pip install Cython>=0.29` first and then force pip to use the modern backend with `pip install --use-pep517 .[madmom]` (or `PIP_USE_PEP517=1`). The upstream `madmom` sdist imports Cython during its build and otherwise falls back to legacy `setup_requires`, which fails without the pre-installed dependency.
 2. Generate the sample click track (writes to the git-ignored `examples/` directory):
    ```bash
    python scripts/make_tiny_click.py
@@ -65,3 +65,9 @@ Use this checklist after modifying the analysis pipeline or rendering code, or b
 1. Remove historical analysis artefacts from `reports/` if disk usage grows large.
 2. Archive important reports before deletion.
 3. Ensure the `reports/` directory remains git-ignored to prevent accidental commits of generated content.
+
+## Troubleshooting
+
+### Windows/Conda: `madmom` extra install fails with `setup_requires`
+- Symptom: running `pip install .[madmom]` during optional extra installation raises an error about unsupported `setup_requires` when building the upstream `madmom` sdist.
+- Fix: pre-install `Cython>=0.29`, then re-run the extra install with `pip install --use-pep517 .[madmom]` (or export `PIP_USE_PEP517=1`) so pip avoids the legacy backend and honours the dependency. This mirrors the guidance in the [README](README.md#installation).


### PR DESCRIPTION
## Summary
- document forcing pip to use the PEP 517 build when installing the `madmom` extra on Windows/Conda
- add a troubleshooting entry linking the README and RUNBOOK guidance for the `madmom` setup failure

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1318a25ac832e991d3938c4a8af91